### PR TITLE
SC-7773 - stabilises rabbitMQ connection

### DIFF
--- a/antivirus_service/consumer.py
+++ b/antivirus_service/consumer.py
@@ -13,6 +13,21 @@ class ScanConsumer(object):
         self.amqp_url = self.amqp_config['url']
         self.amqp_queue = None
 
+        if 'heartbeat' in self.amqp_config:
+            self.heartbeat = self.amqp_config['heartbeat']
+        else:
+            self.heartbeat = 120
+
+        if 'blocked_connection_timeout' in self.amqp_config:
+            self.blocked_connection_timeout = self.amqp_config['blocked_connection_timeout']
+        else:
+            self.blocked_connection_timeout = 60
+
+        if 'socket_timeout' in self.amqp_config:
+            self.socket_timeout = self.amqp_config['socket_timeout']
+        else:
+            self.socket_timeout = 5
+
     def _callback(self, ch, method, properties, body):
         try:
             payload = self.handler.parse_body(body)
@@ -31,7 +46,9 @@ class ScanConsumer(object):
 
     def run(self):
         params = pika.URLParameters(self.amqp_url)
-        params.socket_timeout = 5
+        params.heartbeat = self.heartbeat
+        params.blocked_connection_timeout = self.blocked_connection_timeout
+        params.socket_timeout = self.socket_timeout
         self.connection = pika.BlockingConnection(params)
 
         channel = self.connection.channel()

--- a/antivirus_service/handler.py
+++ b/antivirus_service/handler.py
@@ -39,6 +39,7 @@ class ScanHandler(object):
 
 class ScanFileHandler(ScanHandler):
     def scan(self, download_uri, access_token):
+        sleep_time = 2
         headers = {}
         if access_token:
             headers['Authorization'] = 'Bearer %s' % access_token
@@ -47,7 +48,7 @@ class ScanFileHandler(ScanHandler):
         # that the scan request was triggered before the file upload 
         # has been finished
         last_exception_message = ''
-        count = 5
+        count = 3
         for i in range(1, count):
             try:
                 r = requests.get(download_uri, stream=True, headers=headers)
@@ -59,9 +60,9 @@ class ScanFileHandler(ScanHandler):
                 last_exception_message = str(e)
                 logging.info('file could not downloaded: for {0} time'.format(i))
                 if i < count:
-                    time.sleep(2**i)
+                    time.sleep(sleep_time)
         else:
-            raise Exception('File could not downloaded: {0} - after {1} seconds'.format(last_exception_message, 2**(i+1) - 1))
+            raise Exception('File could not downloaded: {0} - after {1} seconds'.format(last_exception_message, sleep_time * i ))
 
         return self.clamd.scan_file(r)
 

--- a/resources/rabbitmq.config
+++ b/resources/rabbitmq.config
@@ -2,7 +2,8 @@
   {
     rabbit,
       [
-        { loopback_users, [] }
+        { loopback_users, [] },
+        { heartbeat, 120 }
       ]
   },
   {


### PR DESCRIPTION
# Description

The load on the system, coupled with expiration times, makes rabbitMQ drop connections, which leads to K8 pod restarts every few seconds.

In this PR we reduce the number of times a file is attempted to be downloaded, as well as the sleep time. This decrease the blocking connection from ~31 seconds to ~4 seconds.
At the same time, the heartbeat for rabbitMQ is set to be 120 seconds (default is 60)
The client also specifies heartbeat and timeout which can be configured via secrets/config.yml, as [recommended by pika](https://pika.readthedocs.io/en/stable/examples/heartbeat_and_blocked_timeouts.html)

<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-7773
<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
