### PR TITLE
BC-331 - BC-356 - rename ansible variables for OnePassword

### DIFF
--- a/ansible/roles/antivirus_check_service/tasks/main.yml
+++ b/ansible/roles/antivirus_check_service/tasks/main.yml
@@ -9,14 +9,14 @@
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: secret.yml.j2
-    when: ONEPASSWORD is undefined or ONEPASSWORD is defined and not ONEPASSWORD
+    when: ONEPASSWORD_OPERATOR is undefined or ONEPASSWORD_OPERATOR is defined and not ONEPASSWORD_OPERATOR
       
   - name: Secred by 1Password
     community.kubernetes.k8s:
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: onepassword.yml.j2
-    when: ONEPASSWORD is defined and ONEPASSWORD|bool
+    when: ONEPASSWORD_OPERATOR is defined and ONEPASSWORD_OPERATOR|bool
       
   - name: Webserver Deployment
     community.kubernetes.k8s:

--- a/ansible/roles/antivirus_check_service/templates/onepassword.yml.j2
+++ b/ansible/roles/antivirus_check_service/templates/onepassword.yml.j2
@@ -6,4 +6,4 @@ metadata:
   labels:
     app: antivirus
 spec:
-  itemPath: "vaults/{{ VAULT }}/items/antivirus"
+  itemPath: "vaults/{{ ONEPASSWORD_OPERATOR_VAULT }}/items/antivirus"


### PR DESCRIPTION
# Description
Rename ansible variables for OnePassword

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-331
https://ticketsystem.hpi-schul-cloud.org/browse/BC-356

## Changes
Rename ansible variables for OnePassword

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment
https://github.com/hpi-schul-cloud/dof_app_deploy/actions/runs/1283239384

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
