### PR TITLE
BC-1230 - change mode for configmaps to apply

### DIFF
--- a/ansible/roles/antivirus_check_service/tasks/main.yml
+++ b/ansible/roles/antivirus_check_service/tasks/main.yml
@@ -9,6 +9,7 @@
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: secret.yml.j2
+      apply: yes
     when: ONEPASSWORD_OPERATOR is undefined or ONEPASSWORD_OPERATOR is defined and not ONEPASSWORD_OPERATOR
       
   - name: Secred by 1Password


### PR DESCRIPTION
# Description
Change the mode for the configmaps at the ansible roles to apply for configmaps and secrets

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-1230
hpi-schul-cloud/dof_app_deploy#111
hpi-schul-cloud/superhero-dashboard#157
hpi-schul-cloud/schulcloud-server#3311
hpi-schul-cloud/schulcloud-client#2759
hpi-schul-cloud/schulcloud-calendar#109
hpi-schul-cloud/nuxt-client#2040

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
