### PR TITLE
BC-1302 - move the settings form reference to all, will be overwritten for develop

### DIFF
--- a/ansible/group_vars/all/antivirus_check_service.yml
+++ b/ansible/group_vars/all/antivirus_check_service.yml
@@ -1,3 +1,4 @@
 ---
 ANTIVIRUS_PORT: 8080
+ANTIVIRUS_CHECK_SERVICE_IMAGE: schulcloud/schulcloud-avcheck
 

--- a/ansible/group_vars/reference/antivirus_check_service.yml
+++ b/ansible/group_vars/reference/antivirus_check_service.yml
@@ -1,3 +1,0 @@
----
-ANTIVIRUS_CHECK_SERVICE_IMAGE: schulcloud/schulcloud-avcheck
-


### PR DESCRIPTION
# Description
Set the ansible variabel ANTIVIRUS_CHECK_SERVICE_IMAGE will be set default to the schulcloud/schulcloud-avcheck as docker regestry.
It will be overwritten by the value from ansible/group_vars/develop/schulcloud-server.yml for the develop instances

## Links to Tickets or other pull requests
hpi-schul-cloud/schulcloud-server#3321
hpi-schul-cloud/schulcloud-client#2767
hpi-schul-cloud/nuxt-client#2051
hpi-schul-cloud/schulcloud-calendar#112
hpi-schul-cloud/superhero-dashboard#161
https://ticketsystem.hpi-schul-cloud.org/browse/BC-1302

## Approval for review

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.